### PR TITLE
Move the low-level wrapper for cm shell into a dedicated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,9 +580,11 @@ All the relevant C++ source code of the plugin reside in one subdirectory `<Proj
    - `class FPlasticSourceControlModule : public IModuleInterface`
    - Singleton-like entry point of the plugin
  - **PlasticSourceControlUtils**.cpp/.h
-   - `namespace PlasticSourceControlUtils` with free functions and static variables
-   - low level wrapper around the "cm shell" (TODO: move to a dedicated file)
+   - `namespace PlasticSourceControlUtils` with free functions
    - functions wrapping "cm" operations, and their the dedicated parsers (eg "status", "history" etc.)
+ - **PlasticSourceControlShell**.cpp/.h
+   - `namespace PlasticSourceControlShell` with free functions and internal static variables
+   - low level wrapper around the "cm shell" background process
  - **SPlasticSourceControlSettings**.cpp/.h
    - `class SPlasticSourceControlSettings : public SCompoundWidget`
    - the "Source Control Login" window shown above: to enable the plugin, and with a wizard to create the workspace

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlConsole.cpp
@@ -38,8 +38,8 @@ void FPlasticSourceControlConsole::ExecutePlasticConsoleCommand(const TArray<FSt
 	const FString Command = a_args[0];
 	TArray<FString> Parameters = a_args;
 	Parameters.RemoveAt(0);
-	PlasticSourceControlUtils::RunCommandInternal(Command, Parameters, TArray<FString>(), EConcurrency::Synchronous, Results, Errors);
-	if (Results.Len() > 200) // RunCommandInternal() already log all command results up to 200 characters (limit to avoid long wall of text like XML)
+	PlasticSourceControlUtils::RunCommand(Command, Parameters, TArray<FString>(), EConcurrency::Synchronous, Results, Errors);
+	if (Results.Len() > 200) // RunCommand() already log all command results up to 200 characters (limit to avoid long wall of text like XML)
 	{
 		UE_LOG(LogSourceControl, Log, TEXT("Output:\n%s"), *Results);
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -7,6 +7,7 @@
 #include "PlasticSourceControlOperations.h"
 #include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlSettings.h"
+#include "PlasticSourceControlShell.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
 #include "SPlasticSourceControlSettings.h"
@@ -93,7 +94,7 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 		bWorkspaceFound = PlasticSourceControlUtils::FindRootDirectory(PathToProjectDir, PathToWorkspaceRoot);
 
 		// Launch the Plastic SCM cli shell on the background to issue all commands during this session
-		bPlasticAvailable = PlasticSourceControlUtils::LaunchBackgroundPlasticShell(PathToPlasticBinary, PathToWorkspaceRoot);
+		bPlasticAvailable = PlasticSourceControlShell::Launch(PathToPlasticBinary, PathToWorkspaceRoot);
 		if (!bPlasticAvailable)
 		{
 			return;
@@ -126,7 +127,7 @@ void FPlasticSourceControlProvider::Close()
 	// clear the cache
 	StateCache.Empty();
 	// terminate the background 'cm shell' process and associated pipes
-	PlasticSourceControlUtils::Terminate();
+	PlasticSourceControlShell::Terminate();
 	// Remove all extensions to the "Source Control" menu in the Editor Toolbar
 	PlasticSourceControlMenu.Unregister();
 	// Unregister Console Commands

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -1,0 +1,322 @@
+// Copyright (c) 2016-2022 Codice Software
+
+#include "PlasticSourceControlShell.h"
+
+#include "PlasticSourceControlModule.h"
+#include "PlasticSourceControlProvider.h"
+
+#include "ISourceControlModule.h"
+
+#include "HAL/PlatformProcess.h"
+#include "Misc/ScopeLock.h"
+#include "HAL/PlatformTime.h"
+
+#if PLATFORM_LINUX
+#include <sys/ioctl.h>
+#endif
+
+#if PLATFORM_WINDOWS
+#include "Windows/WindowsHWrapper.h" // SECURITY_ATTRIBUTES
+#undef GetUserName
+#endif
+
+
+#if ENGINE_MAJOR_VERSION == 4
+
+// Needed to SetHandleInformation() on WritePipe for input (opposite of ReadPipe, for output) (idem FInteractiveProcess)
+// Note: this has been implemented in Unreal Engine 5.0 in January 2022
+static FORCEINLINE bool CreatePipeWrite(void*& ReadPipe, void*& WritePipe)
+{
+#if PLATFORM_WINDOWS
+	SECURITY_ATTRIBUTES Attr = { sizeof(SECURITY_ATTRIBUTES), NULL, true };
+
+	if (!::CreatePipe(&ReadPipe, &WritePipe, &Attr, 0))
+	{
+		return false;
+	}
+
+	if (!::SetHandleInformation(WritePipe, HANDLE_FLAG_INHERIT, 0))
+	{
+		return false;
+	}
+
+	return true;
+#else
+	return FPlatformProcess::CreatePipe(ReadPipe, WritePipe);
+#endif // PLATFORM_WINDOWS
+}
+
+#endif
+
+namespace PlasticSourceControlShell
+{
+
+// In/Out Pipes for the 'cm shell' persistent child process
+static void*			ShellOutputPipeRead = nullptr;
+static void*			ShellOutputPipeWrite = nullptr;
+static void*			ShellInputPipeRead = nullptr;
+static void*			ShellInputPipeWrite = nullptr;
+static FProcHandle		ShellProcessHandle;
+static FCriticalSection	ShellCriticalSection;
+static size_t			ShellCommandCounter = -1;
+static double			ShellCumulatedTime = 0.;
+
+// Internal function to cleanup (called under the critical section)
+static void _CleanupBackgroundCommandLineShell()
+{
+	FPlatformProcess::ClosePipe(ShellOutputPipeRead, ShellOutputPipeWrite);
+	FPlatformProcess::ClosePipe(ShellInputPipeRead, ShellInputPipeWrite);
+	ShellOutputPipeRead = ShellOutputPipeWrite = nullptr;
+	ShellInputPipeRead = ShellInputPipeWrite = nullptr;
+}
+
+// Internal function to launch the Plastic SCM background 'cm' process in interactive shell mode (called under the critical section)
+static bool _StartBackgroundPlasticShell(const FString& InPathToPlasticBinary, const FString& InWorkingDirectory)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlShell::_StartBackgroundPlasticShell);
+
+	const FString FullCommand(TEXT("shell --encoding=UTF-8"));
+
+	const bool bLaunchDetached = false;				// the new process will NOT have its own window
+	const bool bLaunchHidden = true;				// the new process will be minimized in the task bar
+	const bool bLaunchReallyHidden = bLaunchHidden; // the new process will not have a window or be in the task bar
+
+	const double StartTimestamp = FPlatformTime::Seconds();
+
+#if ENGINE_MAJOR_VERSION == 4
+	verify(FPlatformProcess::CreatePipe(ShellOutputPipeRead, ShellOutputPipeWrite));		// For reading outputs from cm shell child process
+	verify(             CreatePipeWrite(ShellInputPipeRead, ShellInputPipeWrite));			// For writing commands to cm shell child process NOLINT
+#elif ENGINE_MAJOR_VERSION == 5
+	verify(FPlatformProcess::CreatePipe(ShellOutputPipeRead, ShellOutputPipeWrite, false));	// For reading outputs from cm shell child process
+	verify(FPlatformProcess::CreatePipe(ShellInputPipeRead, ShellInputPipeWrite, true));	// For writing commands to cm shell child process
+#endif
+
+	ShellProcessHandle = FPlatformProcess::CreateProc(*InPathToPlasticBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, *InWorkingDirectory, ShellOutputPipeWrite, ShellInputPipeRead);
+	if (!ShellProcessHandle.IsValid())
+	{
+		UE_LOG(LogSourceControl, Warning, TEXT("Failed to launch 'cm shell'")); // not a bug, just no Plastic SCM cli found
+		_CleanupBackgroundCommandLineShell();
+	}
+	else
+	{
+		const double ElapsedTime = (FPlatformTime::Seconds() - StartTimestamp);
+		UE_LOG(LogSourceControl, Verbose, TEXT("_StartBackgroundPlasticShell: '%s %s' ok (in %.3lfs, handle %d)"), *InPathToPlasticBinary, *FullCommand, ElapsedTime, ShellProcessHandle.Get());
+		ShellCommandCounter = 0;
+		ShellCumulatedTime = ElapsedTime;
+	}
+
+	return ShellProcessHandle.IsValid();
+}
+
+// Internal function (called under the critical section)
+static void _ExitBackgroundCommandLineShell()
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlShell::_ExitBackgroundCommandLineShell);
+
+	if (ShellProcessHandle.IsValid())
+	{
+		if (FPlatformProcess::IsProcRunning(ShellProcessHandle))
+		{
+			// Tell the 'cm shell' to exit
+			FPlatformProcess::WritePipe(ShellInputPipeWrite, TEXT("exit"));
+			// And wait up to one second for its termination
+			const double Timeout = 1.0;
+			const double StartTimestamp = FPlatformTime::Seconds();
+			while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
+			{
+				if ((FPlatformTime::Seconds() - StartTimestamp) > Timeout)
+				{
+					UE_LOG(LogSourceControl, Warning, TEXT("ExitBackgroundCommandLineShell: cm shell didn't stop gracefully in %lfs."), Timeout);
+					FPlatformProcess::TerminateProc(ShellProcessHandle);
+					break;
+				}
+				FPlatformProcess::Sleep(0.01f);
+			}
+		}
+		FPlatformProcess::CloseProc(ShellProcessHandle);
+		_CleanupBackgroundCommandLineShell();
+	}
+}
+
+// Internal function (called under the critical section)
+static void _RestartBackgroundCommandLineShell()
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const FString& PathToPlasticBinary = Provider.AccessSettings().GetBinaryPath();
+	const FString& WorkingDirectory = Provider.GetPathToWorkspaceRoot();
+
+	_ExitBackgroundCommandLineShell();
+	_StartBackgroundPlasticShell(PathToPlasticBinary, WorkingDirectory);
+}
+
+// Internal function (called under the critical section)
+static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlShell::_RunCommandInternal);
+
+	bool bResult = false;
+
+	ShellCommandCounter++;
+
+	// Detect previous crash of cm.exe and restart 'cm shell'
+	if (!FPlatformProcess::IsProcRunning(ShellProcessHandle))
+	{
+		UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: 'cm shell' has stopped. Restarting!"));
+		_RestartBackgroundCommandLineShell();
+	}
+
+	// Start with the Plastic command itself ("status", "log", "checkin"...)
+	FString FullCommand = InCommand;
+	// Append to the command all parameters, and then finally the files
+	for (const FString& Parameter : InParameters)
+	{
+		FullCommand += TEXT(" ");
+		FullCommand += Parameter;
+	}
+	for (const FString& File : InFiles)
+	{
+		FullCommand += TEXT(" \"");
+		FullCommand += File;
+		FullCommand += TEXT("\"");
+	}
+	const FString LoggableCommand = FullCommand.Left(256); // Limit command log size to 256 characters
+	UE_LOG(LogSourceControl, Verbose, TEXT("RunCommand: '%s' (%d chars, %d files)"), *LoggableCommand, FullCommand.Len()+1, InFiles.Num());
+	FullCommand += TEXT('\n'); // Finalize the command line
+
+	// Send command to 'cm shell' process in UTF-8
+	// NOTE: this explicit conversion to UTF-8 shouldn't be needed since FPlatformProcess::WritePipe() says it does it, but reading the implementation for Windows Platform show it merily truncates 16bits to 8bits chars!
+	// NOTE: on the other hand, ReadPipe() does the conversion from UTF-8 correctly already!
+	const FTCHARToUTF8 FullCommandUtf8(*FullCommand);
+	const bool bWriteOk = FPlatformProcess::WritePipe(ShellInputPipeWrite, reinterpret_cast<const uint8*>(FullCommandUtf8.Get()), FullCommandUtf8.Length());
+
+	// And wait up to 180.0 seconds for any kind of output from cm shell: in case of lengthier operation, intermediate output (like percentage of progress) is expected, which would refresh the timeout
+	static const double Timeout = 180.0;
+	const double StartTimestamp = FPlatformTime::Seconds();
+	double LastActivity = StartTimestamp;
+	double LastLog = StartTimestamp;
+	static const double LogInterval = 5.0;
+	int32 PreviousLogLen = 0;
+	while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
+	{
+		FString Output = FPlatformProcess::ReadPipe(ShellOutputPipeRead);
+		if (!Output.IsEmpty())
+		{
+			TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlShell::_RunCommandInternal::ParseOutput);
+
+			LastActivity = FPlatformTime::Seconds(); // freshen the timestamp while cm is still actively outputting information
+			OutResults.Append(MoveTemp(Output));
+			// Search the output for the line containing the result code, also indicating the end of the command
+			const uint32 IndexCommandResult = OutResults.Find(TEXT("CommandResult "), ESearchCase::CaseSensitive, ESearchDir::FromEnd);
+			if (INDEX_NONE != IndexCommandResult)
+			{
+				const uint32 IndexEndResult = OutResults.Find(pchDelim, ESearchCase::CaseSensitive, ESearchDir::FromStart, IndexCommandResult + 14);
+				if (INDEX_NONE != IndexEndResult)
+				{
+					const FString Result = OutResults.Mid(IndexCommandResult + 14, IndexEndResult - IndexCommandResult - 14);
+					const int32 ResultCode = FCString::Atoi(*Result);
+					bResult = (ResultCode == 0);
+					// remove the CommandResult line from the OutResults
+					OutResults.RemoveAt(IndexCommandResult, OutResults.Len() - IndexCommandResult);
+					break;
+				}
+			}
+		}
+		else if ((FPlatformTime::Seconds() - LastLog > LogInterval) && (PreviousLogLen < OutResults.Len()))
+		{
+			// In case of long running operation, start to print intermediate output from cm shell (like percentage of progress)
+			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs...\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), *OutResults.Mid(PreviousLogLen));
+			PreviousLogLen = OutResults.Len();
+			LastLog = FPlatformTime::Seconds(); // freshen the timestamp of last log
+		}
+		else if (FPlatformTime::Seconds() - LastActivity > Timeout)
+		{
+			// In case of timeout, ask the blocking 'cm shell' process to exit, detach from it and restart it immediately
+			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
+			_RestartBackgroundCommandLineShell();
+			return false;
+		}
+		else if (IsEngineExitRequested())
+		{
+			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
+			_ExitBackgroundCommandLineShell();
+		}
+
+		TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlShell::_RunCommandInternal::Sleep);
+		FPlatformProcess::Sleep(0.001f);
+	}
+	const double ElapsedTime = (FPlatformTime::Seconds() - StartTimestamp);
+
+	if (!InCommand.Equals(TEXT("exit")))
+	{
+		if (!FPlatformProcess::IsProcRunning(ShellProcessHandle))
+		{
+			// 'cm shell' normally only terminates in case of 'exit' command. Will restart on next command.
+			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' 'cm shell' stopped after %.3lfs output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
+		}
+		else if (!bResult)
+		{
+			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
+		}
+		else
+		{
+			if (PreviousLogLen > 0)
+			{
+				UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Mid(PreviousLogLen).Left(4096)); // Limit result size to 4096 characters
+			}
+			else
+			{
+				if (OutResults.Len() <= 200) // Limit result size to 200 characters
+				{
+					UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults);
+				}
+				else
+				{
+					UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) (output %d chars not displayed)"), *LoggableCommand, ElapsedTime, OutResults.Len());
+					UE_LOG(LogSourceControl, Verbose, TEXT("\n%s"), *OutResults.Left(4096));; // Limit result size to 4096 characters
+				}
+			}
+		}
+	}
+	// Return output as error if result code is an error
+	if (!bResult)
+	{
+		OutErrors = MoveTemp(OutResults);
+	}
+
+	ShellCumulatedTime += ElapsedTime;
+	UE_LOG(LogSourceControl, Verbose, TEXT("RunCommand: cumulated time spent in shell: %.3lfs (count %d)"), ShellCumulatedTime, ShellCommandCounter);
+
+	return bResult;
+}
+
+// Launch the Plastic SCM 'cm shell' process in background for optimized successive commands (thread-safe)
+bool Launch(const FString& InPathToPlasticBinary, const FString& InWorkingDirectory)
+{
+	// Protect public APIs from multi-thread access
+	FScopeLock Lock(&ShellCriticalSection);
+
+	// terminate previous shell if one is already running
+	_ExitBackgroundCommandLineShell();
+
+	return _StartBackgroundPlasticShell(InPathToPlasticBinary, InWorkingDirectory);
+}
+
+// Terminate the background 'cm shell' process and associated pipes (thread-safe)
+void Terminate()
+{
+	// Protect public APIs from multi-thread access
+	FScopeLock Lock(&ShellCriticalSection);
+
+	_ExitBackgroundCommandLineShell();
+}
+
+// Run command and return the raw result
+bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
+{
+	// Protect public APIs from multi-thread access
+	FScopeLock Lock(&ShellCriticalSection);
+
+	return _RunCommandInternal(InCommand, InParameters, InFiles, InConcurrency, OutResults, OutErrors);
+}
+
+} // namespace PlasticSourceControlShell

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2022 Codice Software
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ISourceControlProvider.h" // for EConcurrency
+
+namespace PlasticSourceControlShell
+{
+#if PLATFORM_WINDOWS
+	constexpr TCHAR* pchDelim = TEXT("\r\n");
+#else
+	constexpr TCHAR* pchDelim = TEXT("\n");
+#endif
+
+
+/**
+ * Launch the Plastic SCM "shell" command line process to run it in the background.
+ *
+ * @param	InPathToPlasticBinary	The path to the Plastic binary
+ * @param	InWorkspaceRoot			The workspace from where to run the command - usually the Game directory
+ * @returns true if the command succeeded and returned no errors
+ */
+bool Launch(const FString& InPathToPlasticBinary, const FString& InWorkspaceRoot);
+
+/** Terminate the background 'cm shell' process and associated pipes */
+void Terminate();
+
+
+/**
+ * Run a Plastic command - the result is the output of cm, as a multi-line string.
+ *
+ * @param	InCommand			The Plastic command - e.g. commit
+ * @param	InParameters		The parameters to the Plastic command
+ * @param	InFiles				The files to be operated on
+ * @param	InConcurrency		Is the command running in the background, or blocking the main thread
+ * @param	OutResults			The results (from StdOut) as a multi-line string.
+ * @param	OutErrors			Any errors (from StdErr) as a multi-line string.
+ * @returns true if the command succeeded and returned no errors
+ */
+bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors);
+
+} // namespace PlasticSourceControlShell

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -7,7 +7,10 @@
 #include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlProvider.h"
 #include "PlasticSourceControlSettings.h"
+#include "PlasticSourceControlShell.h"
 #include "PlasticSourceControlState.h"
+#include "ISourceControlModule.h"
+
 #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION == 4
 #include "HAL/PlatformFilemanager.h"
@@ -16,13 +19,9 @@
 #endif
 #include "HAL/PlatformProcess.h"
 #include "HAL/FileManager.h"
-#include "Misc/ScopeLock.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
-#include "HAL/PlatformTime.h"
-#include "Modules/ModuleManager.h"
 #include "XmlParser.h"
-#include "ISourceControlModule.h"
 #include "SoftwareVersion.h"
 
 #if ENGINE_MAJOR_VERSION == 5
@@ -30,24 +29,6 @@
 #include "PlasticSourceControlChangelistState.h"
 #endif
 
-#if PLATFORM_LINUX
-#include <sys/ioctl.h>
-#endif
-
-#if PLATFORM_WINDOWS
-#include "Windows/WindowsHWrapper.h" // SECURITY_ATTRIBUTES
-#undef GetUserName
-#endif
-
-
-namespace PlasticSourceControlConstants
-{
-#if PLATFORM_WINDOWS
-	const TCHAR* pchDelim = TEXT("\r\n");
-#else
-	const TCHAR* pchDelim = TEXT("\n");
-#endif
-}
 
 FScopedTempFile::FScopedTempFile(const FString& InText)
 {
@@ -83,313 +64,25 @@ const FString& FScopedTempFile::GetFilename() const
 	return Filename;
 }
 
-#if ENGINE_MAJOR_VERSION == 4
-
-// Needed to SetHandleInformation() on WritePipe for input (opposite of ReadPipe, for output) (idem FInteractiveProcess)
-// Note: this has been implemented in Unreal Engine 5.0 in January 2022
-static FORCEINLINE bool CreatePipeWrite(void*& ReadPipe, void*& WritePipe)
-{
-#if PLATFORM_WINDOWS
-	SECURITY_ATTRIBUTES Attr = { sizeof(SECURITY_ATTRIBUTES), NULL, true };
-
-	if (!::CreatePipe(&ReadPipe, &WritePipe, &Attr, 0))
-	{
-		return false;
-	}
-
-	if (!::SetHandleInformation(WritePipe, HANDLE_FLAG_INHERIT, 0))
-	{
-		return false;
-	}
-
-	return true;
-#else
-	return FPlatformProcess::CreatePipe(ReadPipe, WritePipe);
-#endif // PLATFORM_WINDOWS
-}
-
-#endif
-
 namespace PlasticSourceControlUtils
 {
-// In/Out Pipes for the 'cm shell' persistent child process
-static void*			ShellOutputPipeRead = nullptr;
-static void*			ShellOutputPipeWrite = nullptr;
-static void*			ShellInputPipeRead = nullptr;
-static void*			ShellInputPipeWrite = nullptr;
-static FProcHandle		ShellProcessHandle;
-static FCriticalSection	ShellCriticalSection;
-static size_t			ShellCommandCounter = -1;
-static double			ShellCumulatedTime = 0.;
 
-// Internal function to cleanup (called under the critical section)
-static void _CleanupBackgroundCommandLineShell()
+// Run a command and return the result as raw strings
+bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
 {
-	FPlatformProcess::ClosePipe(ShellOutputPipeRead, ShellOutputPipeWrite);
-	FPlatformProcess::ClosePipe(ShellInputPipeRead, ShellInputPipeWrite);
-	ShellOutputPipeRead = ShellOutputPipeWrite = nullptr;
-	ShellInputPipeRead = ShellInputPipeWrite = nullptr;
+	return PlasticSourceControlShell::RunCommand(InCommand, InParameters, InFiles, InConcurrency, OutResults, OutErrors);
 }
 
-// Internal function to launch the Plastic SCM background 'cm' process in interactive shell mode (called under the critical section)
-static bool _StartBackgroundPlasticShell(const FString& InPathToPlasticBinary, const FString& InWorkingDirectory)
-{
-	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::_StartBackgroundPlasticShell);
-
-	const FString FullCommand(TEXT("shell --encoding=UTF-8"));
-
-	const bool bLaunchDetached = false;				// the new process will NOT have its own window
-	const bool bLaunchHidden = true;				// the new process will be minimized in the task bar
-	const bool bLaunchReallyHidden = bLaunchHidden; // the new process will not have a window or be in the task bar
-
-	const double StartTimestamp = FPlatformTime::Seconds();
-
-#if ENGINE_MAJOR_VERSION == 4
-	verify(FPlatformProcess::CreatePipe(ShellOutputPipeRead, ShellOutputPipeWrite));		// For reading outputs from cm shell child process
-	verify(             CreatePipeWrite(ShellInputPipeRead, ShellInputPipeWrite));			// For writing commands to cm shell child process NOLINT
-#elif ENGINE_MAJOR_VERSION == 5
-	verify(FPlatformProcess::CreatePipe(ShellOutputPipeRead, ShellOutputPipeWrite, false));	// For reading outputs from cm shell child process
-	verify(FPlatformProcess::CreatePipe(ShellInputPipeRead, ShellInputPipeWrite, true));	// For writing commands to cm shell child process
-#endif
-
-	ShellProcessHandle = FPlatformProcess::CreateProc(*InPathToPlasticBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, *InWorkingDirectory, ShellOutputPipeWrite, ShellInputPipeRead);
-	if (!ShellProcessHandle.IsValid())
-	{
-		UE_LOG(LogSourceControl, Warning, TEXT("Failed to launch 'cm shell'")); // not a bug, just no Plastic SCM cli found
-		_CleanupBackgroundCommandLineShell();
-	}
-	else
-	{
-		const double ElapsedTime = (FPlatformTime::Seconds() - StartTimestamp);
-		UE_LOG(LogSourceControl, Verbose, TEXT("_StartBackgroundPlasticShell: '%s %s' ok (in %.3lfs, handle %d)"), *InPathToPlasticBinary, *FullCommand, ElapsedTime, ShellProcessHandle.Get());
-		ShellCommandCounter = 0;
-		ShellCumulatedTime = ElapsedTime;
-	}
-
-	return ShellProcessHandle.IsValid();
-}
-
-// Internal function (called under the critical section)
-static void _ExitBackgroundCommandLineShell()
-{
-	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::_ExitBackgroundCommandLineShell);
-
-	if (ShellProcessHandle.IsValid())
-	{
-		if (FPlatformProcess::IsProcRunning(ShellProcessHandle))
-		{
-			// Tell the 'cm shell' to exit
-			FPlatformProcess::WritePipe(ShellInputPipeWrite, TEXT("exit"));
-			// And wait up to one second for its termination
-			const double Timeout = 1.0;
-			const double StartTimestamp = FPlatformTime::Seconds();
-			while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
-			{
-				if ((FPlatformTime::Seconds() - StartTimestamp) > Timeout)
-				{
-					UE_LOG(LogSourceControl, Warning, TEXT("ExitBackgroundCommandLineShell: cm shell didn't stop gracefully in %lfs."), Timeout);
-					FPlatformProcess::TerminateProc(ShellProcessHandle);
-					break;
-				}
-				FPlatformProcess::Sleep(0.01f);
-			}
-		}
-		FPlatformProcess::CloseProc(ShellProcessHandle);
-		_CleanupBackgroundCommandLineShell();
-	}
-}
-
-// Internal function (called under the critical section)
-static void _RestartBackgroundCommandLineShell()
-{
-	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const FString& PathToPlasticBinary = Provider.AccessSettings().GetBinaryPath();
-	const FString& WorkingDirectory = Provider.GetPathToWorkspaceRoot();
-
-	_ExitBackgroundCommandLineShell();
-	_StartBackgroundPlasticShell(PathToPlasticBinary, WorkingDirectory);
-}
-
-// Internal function (called under the critical section)
-static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
-{
-	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::_RunCommandInternal);
-
-	bool bResult = false;
-
-	ShellCommandCounter++;
-
-	// Detect previous crash of cm.exe and restart 'cm shell'
-	if (!FPlatformProcess::IsProcRunning(ShellProcessHandle))
-	{
-		UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: 'cm shell' has stopped. Restarting!"));
-		_RestartBackgroundCommandLineShell();
-	}
-
-	// Start with the Plastic command itself ("status", "log", "checkin"...)
-	FString FullCommand = InCommand;
-	// Append to the command all parameters, and then finally the files
-	for (const FString& Parameter : InParameters)
-	{
-		FullCommand += TEXT(" ");
-		FullCommand += Parameter;
-	}
-	for (const FString& File : InFiles)
-	{
-		FullCommand += TEXT(" \"");
-		FullCommand += File;
-		FullCommand += TEXT("\"");
-	}
-	const FString LoggableCommand = FullCommand.Left(256); // Limit command log size to 256 characters
-	UE_LOG(LogSourceControl, Verbose, TEXT("RunCommand: '%s' (%d chars, %d files)"), *LoggableCommand, FullCommand.Len()+1, InFiles.Num());
-	FullCommand += TEXT('\n'); // Finalize the command line
-
-	// Send command to 'cm shell' process in UTF-8
-	// NOTE: this explicit conversion to UTF-8 shouldn't be needed since FPlatformProcess::WritePipe() says it does it, but reading the implementation for Windows Platform show it merily truncates 16bits to 8bits chars!
-	// NOTE: on the other hand, ReadPipe() does the conversion from UTF-8 correctly already!
-	const FTCHARToUTF8 FullCommandUtf8(*FullCommand);
-	const bool bWriteOk = FPlatformProcess::WritePipe(ShellInputPipeWrite, reinterpret_cast<const uint8*>(FullCommandUtf8.Get()), FullCommandUtf8.Length());
-
-	// And wait up to 180.0 seconds for any kind of output from cm shell: in case of lengthier operation, intermediate output (like percentage of progress) is expected, which would refresh the timeout
-	static const double Timeout = 180.0;
-	const double StartTimestamp = FPlatformTime::Seconds();
-	double LastActivity = StartTimestamp;
-	double LastLog = StartTimestamp;
-	static const double LogInterval = 5.0;
-	int32 PreviousLogLen = 0;
-	while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
-	{
-		FString Output = FPlatformProcess::ReadPipe(ShellOutputPipeRead);
-		if (!Output.IsEmpty())
-		{
-			TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::_RunCommandInternal::ParseOutput);
-
-			LastActivity = FPlatformTime::Seconds(); // freshen the timestamp while cm is still actively outputting information
-			OutResults.Append(MoveTemp(Output));
-			// Search the output for the line containing the result code, also indicating the end of the command
-			const uint32 IndexCommandResult = OutResults.Find(TEXT("CommandResult "), ESearchCase::CaseSensitive, ESearchDir::FromEnd);
-			if (INDEX_NONE != IndexCommandResult)
-			{
-				const uint32 IndexEndResult = OutResults.Find(PlasticSourceControlConstants::pchDelim, ESearchCase::CaseSensitive, ESearchDir::FromStart, IndexCommandResult + 14);
-				if (INDEX_NONE != IndexEndResult)
-				{
-					const FString Result = OutResults.Mid(IndexCommandResult + 14, IndexEndResult - IndexCommandResult - 14);
-					const int32 ResultCode = FCString::Atoi(*Result);
-					bResult = (ResultCode == 0);
-					// remove the CommandResult line from the OutResults
-					OutResults.RemoveAt(IndexCommandResult, OutResults.Len() - IndexCommandResult);
-					break;
-				}
-			}
-		}
-		else if ((FPlatformTime::Seconds() - LastLog > LogInterval) && (PreviousLogLen < OutResults.Len()))
-		{
-			// In case of long running operation, start to print intermediate output from cm shell (like percentage of progress)
-			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs...\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), *OutResults.Mid(PreviousLogLen));
-			PreviousLogLen = OutResults.Len();
-			LastLog = FPlatformTime::Seconds(); // freshen the timestamp of last log
-		}
-		else if (FPlatformTime::Seconds() - LastActivity > Timeout)
-		{
-			// In case of timeout, ask the blocking 'cm shell' process to exit, detach from it and restart it immediately
-			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
-			_RestartBackgroundCommandLineShell();
-			return false;
-		}
-		else if (IsEngineExitRequested())
-		{
-			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
-			_ExitBackgroundCommandLineShell();
-		}
-
-		TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::_RunCommandInternal::Sleep);
-		FPlatformProcess::Sleep(0.001f);
-	}
-	const double ElapsedTime = (FPlatformTime::Seconds() - StartTimestamp);
-
-	if (!InCommand.Equals(TEXT("exit")))
-	{
-		if (!FPlatformProcess::IsProcRunning(ShellProcessHandle))
-		{
-			// 'cm shell' normally only terminates in case of 'exit' command. Will restart on next command.
-			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' 'cm shell' stopped after %.3lfs output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
-		}
-		else if (!bResult)
-		{
-			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
-		}
-		else
-		{
-			if (PreviousLogLen > 0)
-			{
-				UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Mid(PreviousLogLen).Left(4096)); // Limit result size to 4096 characters
-			}
-			else
-			{
-				if (OutResults.Len() <= 200) // Limit result size to 200 characters
-				{
-					UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults);
-				}
-				else
-				{
-					UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) (output %d chars not displayed)"), *LoggableCommand, ElapsedTime, OutResults.Len());
-					UE_LOG(LogSourceControl, Verbose, TEXT("\n%s"), *OutResults.Left(4096));; // Limit result size to 4096 characters
-				}
-			}
-		}
-	}
-	// Return output as error if result code is an error
-	if (!bResult)
-	{
-		OutErrors = MoveTemp(OutResults);
-	}
-
-	ShellCumulatedTime += ElapsedTime;
-	UE_LOG(LogSourceControl, Verbose, TEXT("RunCommand: cumulated time spent in shell: %.3lfs (count %d)"), ShellCumulatedTime, ShellCommandCounter);
-
-	return bResult;
-}
-
-// Launch the Plastic SCM background 'cm shell' process in background for optimized successive commands (thread-safe)
-bool LaunchBackgroundPlasticShell(const FString& InPathToPlasticBinary, const FString& InWorkingDirectory)
-{
-	// Protect public APIs from multi-thread access
-	FScopeLock Lock(&ShellCriticalSection);
-
-	// terminate previous shell if one is already running
-	_ExitBackgroundCommandLineShell();
-
-	return _StartBackgroundPlasticShell(InPathToPlasticBinary, InWorkingDirectory);
-}
-
-// Terminate the background 'cm shell' process and associated pipes (thread-safe)
-void Terminate()
-{
-	// Protect public APIs from multi-thread access
-	FScopeLock Lock(&ShellCriticalSection);
-
-	_ExitBackgroundCommandLineShell();
-}
-
-// Run command (thread-safe)
-bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors)
-{
-	// Protect public APIs from multi-thread access
-	FScopeLock Lock(&ShellCriticalSection);
-
-	return _RunCommandInternal(InCommand, InParameters, InFiles, InConcurrency, OutResults, OutErrors);
-}
-
-// Basic parsing or results & errors from the Plastic command line process
+// Run a command with basic parsing or results & errors from the Plastic command line process
 bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages)
 {
 	FString Results;
 	FString Errors;
 
-	const bool bResult = RunCommandInternal(InCommand, InParameters, InFiles, InConcurrency, Results, Errors);
+	const bool bResult = PlasticSourceControlShell::RunCommand(InCommand, InParameters, InFiles, InConcurrency, Results, Errors);
 
-	Results.ParseIntoArray(OutResults, PlasticSourceControlConstants::pchDelim, true);
-	Errors.ParseIntoArray(OutErrorMessages, PlasticSourceControlConstants::pchDelim, true);
+	Results.ParseIntoArray(OutResults, PlasticSourceControlShell::pchDelim, true);
+	Errors.ParseIntoArray(OutErrorMessages, PlasticSourceControlShell::pchDelim, true);
 
 	return bResult;
 }
@@ -1634,7 +1327,7 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 	}
 	if (Files.Num() > 0)
 	{
-		bResult = RunCommandInternal(TEXT("history"), Parameters, Files, EConcurrency::Synchronous, Results, Errors);
+		bResult = RunCommand(TEXT("history"), Parameters, Files, EConcurrency::Synchronous, Results, Errors);
 		if (bResult)
 		{
 			FXmlFile XmlFile;
@@ -1798,7 +1491,7 @@ bool RunGetChangelists(const EConcurrency::Type InConcurrency, TArray<FPlasticSo
 	Parameters.Add(TEXT("--noheader"));
 	Parameters.Add(TEXT("--xml"));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));
-	bool bResult = PlasticSourceControlUtils::RunCommandInternal(TEXT("status"), Parameters, TArray<FString>(), InConcurrency, Results, Errors);
+	bool bResult = RunCommand(TEXT("status"), Parameters, TArray<FString>(), InConcurrency, Results, Errors);
 	if (bResult)
 	{
 		FXmlFile XmlFile;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "ISourceControlProvider.h"
+#include "ISourceControlProvider.h" // for EConcurrency
 #include "PlasticSourceControlRevision.h"
 
 #include "Runtime/Launch/Resources/Version.h"
@@ -43,17 +43,6 @@ const struct FSoftwareVersion& GetOldestSupportedPlasticScmVersion();
  * Find the path to the Plastic binary: for now relying on the Path to access the "cm" command.
  */
 FString FindPlasticBinaryPath();
-
-/**
- * Launch the Plastic SCM "shell" command to run it in background.
- * @param	InPathToPlasticBinary	The path to the Plastic binary
- * @param	InWorkspaceRoot			The workspace from where to run the command - usually the Game directory
- * @returns true if the command succeeded and returned no errors
- */
-bool LaunchBackgroundPlasticShell(const FString& InPathToPlasticBinary, const FString& InWorkspaceRoot);
-
-/** Terminate the background 'cm shell' process and associated pipes */
-void Terminate();
 
 /**
  * Find the root of the Plastic workspace, looking from the GameDir and upward in its parent directories
@@ -103,7 +92,20 @@ bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FS
 FString UserNameToDisplayName(const FString& InUserName);
 
 /**
- * Run a Plastic command - output is a string TArray.
+ * Run a Plastic command - the result is the output of cm, as a multi-line string.
+ *
+ * @param	InCommand			The Plastic command - e.g. commit
+ * @param	InParameters		The parameters to the Plastic command
+ * @param	InFiles				The files to be operated on
+ * @param	InConcurrency		Is the command running in the background, or blocking the main thread
+ * @param	OutResults			The results (from StdOut) as a multi-line string.
+ * @param	OutErrors			Any errors (from StdErr) as a multi-line string.
+ * @returns true if the command succeeded and returned no errors
+ */
+bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors);
+
+/**
+ * Run a Plastic command - the result is parsed in an array of strings.
  *
  * @param	InCommand			The Plastic command - e.g. commit
  * @param	InParameters		The parameters to the Plastic command
@@ -114,8 +116,6 @@ FString UserNameToDisplayName(const FString& InUserName);
  * @returns true if the command succeeded and returned no errors
  */
 bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages);
-// Run a Plastic command - output is a string.
-bool RunCommandInternal(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, const EConcurrency::Type InConcurrency, FString& OutResults, FString& OutErrors);
 
 /**
  * Run a Plastic "status" command and parse it.


### PR DESCRIPTION
With all the internal static variables, only exposing the minimal set of free functions:

- Launch()     (was LaunchBackgroundPlasticShell())
- Terminate()
- RunCommand() (was RunCommandInternal())

Now Utils only contains functions on a higher level, calling RunCommandRaw() and parsing the result