### PR TITLE
Update CreatedBy URL for the plugin

### DIFF
--- a/PlasticSourceControl.uplugin
+++ b/PlasticSourceControl.uplugin
@@ -6,7 +6,7 @@
 	"Description": "Plastic source control management",
 	"Category": "Source Control",
 	"CreatedBy": "Codice Software.",
-	"CreatedByURL": "http://srombauts.github.com",
+	"CreatedByURL": "https://srombauts.github.io",
 	"DocsURL": "https://github.com/PlasticSCM/UEPlasticPlugin",
 	"MarketplaceURL": "",
 	"SupportURL": "https://www.plasticscm.com/support",


### PR DESCRIPTION
Hi, we've made a change in UE 5.2 that will require `https://` protocol in order for CreatedBy links to show up in the plugin browser. I'm updating our Perforce main branch to fix existing plugin URLs where possible. Also, it looks like the previous URL used here doesn't resolve -- it needs either `github.io` or `github.com/SRombauts`.