### PR TITLE
Update workspace detects if it also need to reload the current map

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -488,10 +488,49 @@ void FPlasticSourceControlMenu::OnSourceControlOperationComplete(const FSourceCo
 					UE_LOG(LogSourceControl, Log, TEXT("Reload: %s"), *PackageName);
 				}
 			}
-			// else, it means the file is not an asset from the Content/ folder (eg config, source code, anything else)
+			// else, it means the file is not an asset from the Content/ folGet the World currently loaded by the Editorder (eg config, source code, anything else)
 		}
 
-		// Reload packages that where updated by the Sync operation
+		// Detects if some packages to reload are referencing the current map
+		// (assets that are parts of a map in the new One File Per Actor (OFPA) in UE5 are __ExternalActors__ or __ExternalObjects__)
+		// in which case the current map need to be reloaded, so it needs to be added to the list of packages if not already in
+		// (then UPackageTools::ReloadPackages() will handle unloading the map at the start of the reload, and reloading it at the end)
+		if (UWorld* CurrentWorld = GetCurrentWorld())
+		{
+			bool bNeedReloadCurrentMap = false;
+			UPackage* CurrentMapPackage = CurrentWorld->GetOutermost();
+			const FString CurrentMapPath = *CurrentMapPackage->GetName();					// eg "/Game/Maps/OpenWorld"
+			const FString CurrentMapPathWithoutGamePrefix = CurrentMapPath.RightChop(5);	// eg "/Maps/OpenWorld"
+			const FString GamePath = FString("/Game/");
+			const FString CurrentMapExternalActorPath = GamePath + FPackagePath::GetExternalActorsFolderName() + CurrentMapPathWithoutGamePrefix;	// eg "/Game/__ExternalActors__/Maps/OpenWorld
+			const FString CurrentMapExternalObjectPath = GamePath + FPackagePath::GetExternalObjectsFolderName() + CurrentMapPathWithoutGamePrefix;	// eg "/Game/__ExternalObjects__/Maps/OpenWorld
+
+			for (const UPackage* Package : PackagesToReload)
+			{
+				const FString AssetPath = Package->GetPathName(); // eg "/Game/__ExternalActors__/Maps/OpenWorld/9/HA/BKGJVDMLMCYJBWPTW6VT3K"
+				if (AssetPath == CurrentMapPath)
+				{
+					// if the current world package is already in the list, no need to add it, we can end the search there
+					bNeedReloadCurrentMap = false;
+					break;
+				}
+
+				if (!bNeedReloadCurrentMap) // do these expensive string checks only once:
+				{
+					if (AssetPath.StartsWith(CurrentMapExternalActorPath) || AssetPath.StartsWith(CurrentMapExternalObjectPath))
+					{
+						bNeedReloadCurrentMap = true;
+					}
+				}
+			}
+			if (bNeedReloadCurrentMap)
+			{
+				PackagesToReload.Add(CurrentMapPackage);
+				UE_LOG(LogSourceControl, Log, TEXT("Reload: %s"), *CurrentMapPath);
+			}
+		}
+
+		// Reload packages that where updated by the Sync operation (and the current map if needed)
 		ReloadPackages(PackagesToReload);
 	}
 	else if (InOperation->GetName() == "RevertAll")

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -451,6 +451,20 @@ void FPlasticSourceControlMenu::DisplayFailureNotification(const FName& InOperat
 	UE_LOG(LogSourceControl, Error, TEXT("%s"), *NotificationText.ToString());
 }
 
+// Get the World currently loaded by the Editor (and thus, access to the corresponding map package)
+UWorld* GetCurrentWorld()
+{
+	if (GEditor)
+	{
+		if (UWorld* EditorWorld = GEditor->GetEditorWorldContext().World())
+		{
+			return EditorWorld;
+		}
+	}
+	return nullptr;
+}
+
+
 void FPlasticSourceControlMenu::OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
 {
 	RemoveInProgressNotification();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -10,6 +10,7 @@
 #include "PlasticSourceControlShell.h"
 #include "PlasticSourceControlState.h"
 #include "ISourceControlModule.h"
+#include "ScopedTempFile.h"
 
 #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION == 4
@@ -1440,9 +1441,8 @@ bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, T
 	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
 	if (!bInIsPartialWorkspace)
 	{
-		// TODO: const FScopedTempFile TempFile;
-		const FString TempFilename = FPaths::CreateTempFilename(*FPaths::ConvertRelativePathToFull(FPaths::ProjectLogDir()), TEXT("Plastic-Temp"), TEXT(".xml"));
-		Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *TempFilename));
+		const FScopedTempFile TempFile;
+		Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *TempFile.GetFilename()));
 		Parameters.Add(TEXT("--encoding=\"utf-8\""));
 		Parameters.Add(TEXT("--last"));
 		Parameters.Add(TEXT("--dontmerge"));
@@ -1451,7 +1451,7 @@ bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, T
 		{
 			// Parse the result of the
 			FString Results;
-			if (FFileHelper::LoadFileToString(Results, *TempFilename))
+			if (FFileHelper::LoadFileToString(Results, *TempFile.GetFilename()))
 			{
 				FXmlFile XmlFile;
 				{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1447,7 +1447,7 @@ bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, T
 	{
 		Parameters.Add(TEXT("--last"));
 		Parameters.Add(TEXT("--dontmerge"));
-		bResult = PlasticSourceControlUtils::RunCommand(TEXT("update"), Parameters, InFiles, InfoMessages, OutErrorMessages);
+		bResult = PlasticSourceControlUtils::RunCommand(TEXT("update"), Parameters, TArray<FString>(), InfoMessages, OutErrorMessages);
 	}
 	else
 	{

--- a/Source/PlasticSourceControl/Private/ScopedTempFile.cpp
+++ b/Source/PlasticSourceControl/Private/ScopedTempFile.cpp
@@ -7,6 +7,11 @@
 
 #include "ISourceControlModule.h" // LogSourceControl
 
+FScopedTempFile::FScopedTempFile()
+{
+	Filename = FPaths::CreateTempFilename(*FPaths::ProjectLogDir(), TEXT("Plastic-Temp"), TEXT(".txt"));
+}
+
 FScopedTempFile::FScopedTempFile(const FString& InText)
 {
 	Filename = FPaths::CreateTempFilename(*FPaths::ProjectLogDir(), TEXT("Plastic-Temp"), TEXT(".txt"));

--- a/Source/PlasticSourceControl/Private/ScopedTempFile.h
+++ b/Source/PlasticSourceControl/Private/ScopedTempFile.h
@@ -10,6 +10,9 @@
 class FScopedTempFile
 {
 public:
+	/** Default constructor - only hold a temp filename */
+	FScopedTempFile();
+
 	/** Constructor - open & write string to temp file */
 	explicit FScopedTempFile(const FString& InText);
 	explicit FScopedTempFile(const FText& InText);


### PR DESCRIPTION
Detects if some packages to reload are referencing the current map

in which case the current map need to be reloaded, so it needs to be added to the list of packages if not already in

(assets that are parts of a map in the new One File Per Actor (OFPA) in UE5 are __ExternalActors__ or __ExternalObjects__)
