### PR TITLE
Fix for the 3 way merge tool not showing the Source (Remote) revision…

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1312,6 +1312,11 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 					InOutState.HeadChangeList = SourceControlRevision->ChangesetNumber;
 					InOutState.HeadUserName = SourceControlRevision->UserName;
 					InOutState.HeadModTime = SourceControlRevision->Date.ToUnixTimestamp();
+					// In case of a merge conflict, we need to put the tip of the "remote branch" on top of the history
+					if (SourceControlRevision->ChangesetNumber == InOutState.PendingMergeSourceChangeset)
+					{
+						InOutState.History.Add(SourceControlRevision);
+					}
 				}
 				else if (bInUpdateHistory)
 				{


### PR DESCRIPTION
… of the file, instead showing twice the Target (Local) revision.

In case of a merge conflict, we need to put the tip of the "remote branch" on top of the history; it means that we need to keep this revision in the list of revision even if this is a revision higher than the head/changeset