### PR TITLE
Updated working directory for Linux support

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -105,8 +105,7 @@ static bool _StartBackgroundPlasticShell(const FString& InPathToPlasticBinary, c
 	// Update working directory
 	char OriginalWorkingDirectory[PATH_MAX];
 	getcwd(OriginalWorkingDirectory, PATH_MAX);
-	char* NewWorkingDirectory = TCHAR_TO_ANSI(*InWorkingDirectory);
-	chdir(NewWorkingDirectory);
+	chdir(TCHAR_TO_ANSI(*InWorkingDirectory));
 
 	ShellProcessHandle = FPlatformProcess::CreateProc(*InPathToPlasticBinary, *FullCommand, bLaunchDetached, bLaunchHidden, bLaunchReallyHidden, nullptr, 0, nullptr, ShellOutputPipeWrite, ShellInputPipeRead);
 


### PR DESCRIPTION
- Updates working directory before starting cm.
- FPlatformProcess::CreateProc with nullptr instead of *InWorkingDirectory, just in case because that variable is not used by the engine anyway.
- Restores the original working directory.