### PR TITLE
Added support for "Should Delete New Files on Revert"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -563,7 +563,7 @@ bool FPlasticRevertWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	TSharedRef<FRevert, ESPMode::ThreadSafe> RevertOperation = StaticCastSharedRef<FRevert>(InCommand.Operation);
 
-	bool shouldDeleteNewFiles = RevertOperation->ShouldDeleteNewFiles();
+	bool ShouldDeleteNewFiles = RevertOperation->ShouldDeleteNewFiles();
 #endif
 
 	for (int i = 0; i < Files.Num(); i++) // Required for loop on index since we are adding to the Files array as we go
@@ -588,9 +588,9 @@ bool FPlasticRevertWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		}
 
 #if ENGINE_MAJOR_VERSION == 5
-		if (State->WorkspaceState == EWorkspaceState::Added && shouldDeleteNewFiles)
+		if (State->WorkspaceState == EWorkspaceState::Added && ShouldDeleteNewFiles)
 		{
-			RevertOperation->AddDeletedFile(File);
+			IFileManager::Get().Delete(*File);
 		}
 #endif
 	}


### PR DESCRIPTION
Unreal Engine 5 added a Source Control project settings to let users decide if they want to delete newly added files when calling Revert (true by default).

This PR covers the support for that parameter, keeping new files as "Private" when the setting is disable, and removing the new files from disk when it is enable.