### PR TITLE
Improve performances of "move" by not grouping the final "status" on both source & destination files if they are not on the same folder.

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1100,11 +1100,22 @@ bool FPlasticCopyWorker::Execute(FPlasticSourceControlCommand& InCommand)
 			InCommand.bCommandSuccessful = true;
 		}
 
-		// now update the status of our files:
-		TArray<FString> BothFiles;
-		BothFiles.Add(Origin);
-		BothFiles.Add(Destination);
-		PlasticSourceControlUtils::RunUpdateStatus(BothFiles, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+		// Now update the status of both our files
+		// Note: this call "status" on the common directory of both files, that could very well be the root Content/ folder itself, leading to an expensive call checking status of the whole project
+		// There is no perfect heuristic to know when a directory status is more expensive that two file status,
+		// let's assume that a "rename" (ie. source & destination in the same directory) is always worth grouping, while a "move" (different directories) is more at risk to create a huge status update.
+		if (FPaths::GetPath(Origin) == (FPaths::GetPath(Destination)))
+		{
+			TArray<FString> BothFiles;
+			BothFiles.Add(Origin);
+			BothFiles.Add(Destination);
+			PlasticSourceControlUtils::RunUpdateStatus(BothFiles, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+		}
+		else
+		{
+			PlasticSourceControlUtils::RunUpdateStatus({ Origin }, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+			PlasticSourceControlUtils::RunUpdateStatus({ Destination }, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Reasoning: the final "status" call on the common directory of both files could very well operate on the root Content/ folder itself, leading to an expensive call checking status of the whole project

As there is no perfect heuristic to know when a directory status is more expensive that two file status, let's assume that a "rename" (ie. source & destination in the same directory) is always worth grouping, while a "move" (different directories) is more at risk to create a huge status update.

This has the potential to help a lot on big game project, where a call to a "full Content/ status" can take seconds (so moving 100 assets might take 1000s less). The downside is that it will slow down the status on small project where it only takes around 100ms (where moving 100 assets might take 10s more).