### PR TITLE
Add an option to create a Gluon partial workspace

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -903,6 +903,12 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 		Parameters.Add(FString::Printf(TEXT("--repository=rep:%s@repserver:%s"), *Operation->RepositoryName, *Operation->ServerUrl));
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("makeworkspace"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
 	}
+	if (Operation->bPartialWorkspace)
+	{
+		TArray<FString> Parameters;
+		Parameters.Add(TEXT("update"));
+		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+	}
 
 	return InCommand.bCommandSuccessful;
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -104,7 +104,7 @@ FName FPlasticMakeWorkspace::GetName() const
 
 FText FPlasticMakeWorkspace::GetInProgressString() const
 {
-	return LOCTEXT("SourceControl_MakeWorkspace", "Creating a new Repository and initializing the Workspace");
+	return LOCTEXT("SourceControl_MakeWorkspace", "Creating a new Repository and Workspace");
 }
 
 FName FPlasticSwitchToPartialWorkspace::GetName() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -68,7 +68,7 @@ public:
 
 
 /**
-* Internal operation used to initialize a new Workspace and a new Repository
+* Internal operation used to create a new Workspace and a new Repository
 */
 class FPlasticMakeWorkspace final : public ISourceControlOperation
 {
@@ -270,7 +270,7 @@ public:
 	TArray<FPlasticSourceControlState> States;
 };
 
-/** Initialize a new Workspace and a new Repository */
+/** Create a new Workspace and a new Repository */
 class FPlasticMakeWorkspaceWorker final : public IPlasticSourceControlWorker
 {
 public:

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -81,6 +81,7 @@ public:
 	FString WorkspaceName;
 	FString RepositoryName;
 	FString ServerUrl;
+	bool bPartialWorkspace;
 };
 
 

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -249,6 +249,23 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
+		// Option to create a Partial/Gluon Workspace designed
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(SCheckBox)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
+			.ToolTipText(LOCTEXT("CreatePartialWorkspace_Tooltip", "Create the new workspace in Gluon/partial mode, designed for artists."))
+			.IsChecked(bCreatePartialWorkspace)
+			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedCreatePartialWorkspace)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("CreatePartialWorkspace", "Make the new workspace a Gluon partial workspace."))
+				.Font(Font)
+			]
+		]
 		// Option to add a 'ignore.conf' file at Workspace creation time
 		+SVerticalBox::Slot()
 		.AutoHeight()
@@ -485,6 +502,16 @@ FText SPlasticSourceControlSettings::GetServerUrl() const
 	return ServerUrl;
 }
 
+bool SPlasticSourceControlSettings::CreatePartialWorkspace() const
+{
+	return bCreatePartialWorkspace;
+}
+
+void SPlasticSourceControlSettings::OnCheckedCreatePartialWorkspace(ECheckBoxState NewCheckedState)
+{
+	bCreatePartialWorkspace = (NewCheckedState == ECheckBoxState::Checked);
+}
+
 bool SPlasticSourceControlSettings::CanAutoCreateIgnoreFile() const
 {
 	const bool bIgnoreFileFound = FPaths::FileExists(GetIgnoreFileName());
@@ -531,6 +558,7 @@ void SPlasticSourceControlSettings::LaunchMakeWorkspaceOperation()
 	MakeWorkspaceOperation->WorkspaceName = WorkspaceName.ToString();
 	MakeWorkspaceOperation->RepositoryName = RepositoryName.ToString();
 	MakeWorkspaceOperation->ServerUrl = ServerUrl.ToString();
+	MakeWorkspaceOperation->bPartialWorkspace = bCreatePartialWorkspace;
 
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 	ECommandResult::Type Result = Provider.Execute(MakeWorkspaceOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlSettings::OnSourceControlOperationComplete));

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -179,7 +179,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.Padding(2.0f, 5.0f)
 		[
 			SNew(STextBlock)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			.ToolTipText(LOCTEXT("WorkspaceNotFound_Tooltip", "No Workspace found at the level or above the current Project. Use the form to create a new one."))
 			.Text(LOCTEXT("WorkspaceNotFound", "Current Project is not in a Unity Version Control Workspace. Create a new one:"))
 			.Font(Font)
@@ -191,7 +191,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			[
@@ -230,7 +230,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			.ToolTipText(LOCTEXT("ServerUrl_Tooltip", "Enter the Server URL in the form address:port (eg. YourOrganization@cloud, local, or something like ip:port, eg localhost:8087)"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
@@ -256,7 +256,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SCheckBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			.ToolTipText(LOCTEXT("CreateIgnoreFile_Tooltip", "Create and add a standard 'ignore.conf' file"))
 			.IsEnabled(this, &SPlasticSourceControlSettings::CanAutoCreateIgnoreFile)
 			.IsChecked(bAutoCreateIgnoreFile)
@@ -274,7 +274,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			.ToolTipText(LOCTEXT("InitialCommit_Tooltip", "Make the initial Unity Version Control checkin"))
 			+SHorizontalBox::Slot()
 			.FillWidth(0.7f)
@@ -358,15 +358,15 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanInitializePlasticWorkspace)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			[
 				SNew(SButton)
-				.IsEnabled(this, &SPlasticSourceControlSettings::IsReadyToInitializePlasticWorkspace)
+				.IsEnabled(this, &SPlasticSourceControlSettings::IsReadyToCreatePlasticWorkspace)
 				.Text(LOCTEXT("PlasticInitWorkspace", "Create a new Unity Version Control workspace for the current project"))
-				.ToolTipText(LOCTEXT("PlasticInitWorkspace_Tooltip", "Create and initialize a new Unity Version Control workspace and repository for the current project"))
-				.OnClicked(this, &SPlasticSourceControlSettings::OnClickedInitializePlasticWorkspace)
+				.ToolTipText(LOCTEXT("PlasticInitWorkspace_Tooltip", "Create a new Unity Version Control repository and workspace and for the current project"))
+				.OnClicked(this, &SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace)
 				.HAlign(HAlign_Center)
 				.ContentPadding(6)
 			]
@@ -438,7 +438,7 @@ FText SPlasticSourceControlSettings::GetUserName() const
 }
 
 
-EVisibility SPlasticSourceControlSettings::CanInitializePlasticWorkspace() const
+EVisibility SPlasticSourceControlSettings::CanCreatePlasticWorkspace() const
 {
 	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
@@ -446,7 +446,7 @@ EVisibility SPlasticSourceControlSettings::CanInitializePlasticWorkspace() const
 	return (bPlasticAvailable && !bPlasticWorkspaceFound) ? EVisibility::Visible : EVisibility::Collapsed;
 }
 
-bool SPlasticSourceControlSettings::IsReadyToInitializePlasticWorkspace() const
+bool SPlasticSourceControlSettings::IsReadyToCreatePlasticWorkspace() const
 {
 	// Workspace Name cannot be left empty
 	const bool bWorkspaceNameOk = !WorkspaceName.IsEmpty();
@@ -512,9 +512,9 @@ FText SPlasticSourceControlSettings::GetInitialCommitMessage() const
 }
 
 
-FReply SPlasticSourceControlSettings::OnClickedInitializePlasticWorkspace()
+FReply SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace()
 {
-	UE_LOG(LogSourceControl, Log, TEXT("InitializePlasticWorkspace(%s, %s, %s) CreateIgnore=%d Commit=%d"),
+	UE_LOG(LogSourceControl, Log, TEXT("CreatePlasticWorkspace(%s, %s, %s) CreateIgnore=%d Commit=%d"),
 		*WorkspaceName.ToString(), *RepositoryName.ToString(), *ServerUrl.ToString(), bAutoCreateIgnoreFile, bAutoInitialCommit);
 
 	// 1.a. Create a repository (if not already existing) and a workspace: launch an asynchronous MakeWorkspace operation

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -48,6 +48,9 @@ private:
 	void OnServerUrlCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetServerUrl() const;
 	FText ServerUrl;
+	bool CreatePartialWorkspace() const;
+	void OnCheckedCreatePartialWorkspace(ECheckBoxState NewCheckedState);
+	bool bCreatePartialWorkspace;
 	bool CanAutoCreateIgnoreFile() const;
 	void OnCheckedCreateIgnoreFile(ECheckBoxState NewCheckedState);
 	bool bAutoCreateIgnoreFile;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -36,9 +36,9 @@ private:
 	FText GetPathToWorkspaceRoot() const;
 	FText GetUserName() const;
 
-	/** Delegate to initialize a new Plastic workspace and repository */
-	EVisibility CanInitializePlasticWorkspace() const;
-	bool IsReadyToInitializePlasticWorkspace() const;
+	/** Delegate to create a new Plastic workspace and repository */
+	EVisibility CanCreatePlasticWorkspace() const;
+	bool IsReadyToCreatePlasticWorkspace() const;
 	void OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetWorkspaceName() const;
 	FText WorkspaceName;
@@ -83,7 +83,7 @@ private:
 	void DisplaySuccessNotification(const FName& InOperationName);
 	void DisplayFailureNotification(const FName& InOperationName);
 
-	FReply OnClickedInitializePlasticWorkspace();
+	FReply OnClickedCreatePlasticWorkspace();
 
 	/** Delegate to add a Plastic ignore.conf file to an existing Plastic workspace */
 	EVisibility CanAddIgnoreFile() const;


### PR DESCRIPTION
When creating a new repository & workspace, add a checkbox option to make it a partial workspace to be used with Gluon.

- Reword "initialize" to "create" in comments and code to match the UI. The old naming was coming from the Git plugin ("git init") while the underlying commands are now "cm repo/workspace create"
- Add a bPartialWorkspace to the FPlasticMakeWorkspace operation
- Add a call to "partial update" to FPlasticMakeWorkspaceWorker implementation
- Add the tick-box option to create a Gluon Partial Workspace from the Login / Settings window