### PR TITLE
Fix history of a renamed asset

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -823,14 +823,14 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 	return true;
 }
 
-bool ParseHistoryResults(const bool bInUpdateHistory, const FString& InResults, TArray<FPlasticSourceControlState>& InOutStates)
+bool ParseHistoryResults(const bool bInUpdateHistory, const FString& InResultFilename, TArray<FPlasticSourceControlState>& InOutStates)
 {
 	bool bResult = false;
 
 	FXmlFile XmlFile;
 	{
 		TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlParsers::ParseHistoryResults::FXmlFile::LoadFile);
-		bResult = XmlFile.LoadFile(InResults, EConstructMethod::ConstructFromBuffer);
+		bResult = XmlFile.LoadFile(InResultFilename);
 	}
 	if (bResult)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -72,7 +72,7 @@ void ParseDirectoryStatusResult(const FString& InDir, const TArray<FString>& InR
 
 void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlasticSourceControlState>& InOutStates);
 
-bool ParseHistoryResults(const bool bInUpdateHistory, const FString& InResults, TArray<FPlasticSourceControlState>& InOutStates);
+bool ParseHistoryResults(const bool bInUpdateHistory, const FString& InResultFilename, TArray<FPlasticSourceControlState>& InOutStates);
 
 bool ParseUpdateResults(const FString& InResults, TArray<FString>& OutFiles);
 bool ParseUpdateResults(const TArray<FString>& InResults, TArray<FString>& OutFiles);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -671,23 +671,6 @@ bool RunGetFile(const FString& InRevSpec, const FString& InDumpFileName)
 	return bResult;
 }
 
-// Convert a file state to a string ala Perforce, see also ParseShelveFileStatus()
-FString FileStateToAction(const EWorkspaceState InState)
-{
-	switch (InState)
-	{
-	case EWorkspaceState::Added:
-		return TEXT("add");
-	case EWorkspaceState::Deleted:
-		return TEXT("delete");
-	case EWorkspaceState::Moved:
-		return TEXT("branch");
-	case EWorkspaceState::CheckedOutChanged:
-	default:
-		return TEXT("edit");
-	}
-}
-
 // Run a Plastic "history" command and parse it's XML result.
 bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlState>& InOutStates, TArray<FString>& OutErrorMessages)
 {

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -685,7 +685,8 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 	{
 		Parameters.Add(TEXT("--moveddeleted"));
 	}
-	Parameters.Add(TEXT("--xml"));
+	const FScopedTempFile HistoryResultFile;
+	Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *HistoryResultFile.GetFilename()));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));
 	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 	if (Provider.GetPlasticScmVersion() >= PlasticSourceControlVersions::NewHistoryLimit)
@@ -720,7 +721,7 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 		bResult = RunCommand(TEXT("history"), Parameters, Files, Results, Errors);
 		if (bResult)
 		{
-			bResult = PlasticSourceControlParsers::ParseHistoryResults(bInUpdateHistory, Results, InOutStates);
+			bResult = PlasticSourceControlParsers::ParseHistoryResults(bInUpdateHistory, HistoryResultFile.GetFilename(), InOutStates);
 		}
 		if (!Errors.IsEmpty())
 		{


### PR DESCRIPTION
An asset that as been renamed was showing up with a "deleted" cross icon in its history
![image](https://github.com/SRombauts/UEPlasticPlugin/assets/101874327/a34e3f33-c8eb-4d37-b1cb-86f8087f5032)

- Removed duplicated and unused FileStateToAction() from Utils. It belongs in Parsers, where it is used.
- Change FileStateToAction() to extract and use directly the source control action text strings. Better than calling the function in the parser's inner loop!
- cm delivers the history into an XML file. instead of outputting it directly on the standard output of the shell